### PR TITLE
Add support for bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,11 @@
+[bumpversion]
+current_version = 1.4.2
+commit = True
+tag = True
+sign_tags = True
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:optbeam/__init__.py]
+
+[bumpversion:file:CITATION.cff]

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ with open("README.md") as f:
 with open("LICENSE") as f:
     license = f.read()
 
+extras = {
+    'dev': ['bump2version'],
+}
+
 setup(
     name="optbeam",
     version="1.4.2",
@@ -21,4 +25,5 @@ setup(
     packages=find_packages(exclude=("scripts")),
     include_package_data=True,
     install_requires=["scipy"],
+    extras_require=extras,
 )


### PR DESCRIPTION
This enables to consistently increase the version number at all relevant places in the repository by just one command:
```shell
$ bumpversion minor
```
which will increase the minor of the version number, commit and tag this change appropriately.